### PR TITLE
Try to prevent deletions on API throttling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject calligraphus "0.1.0"
+(defproject calligraphus "0.1.1"
   :description "Meetup.com API aggregator for Papers We Love"
   :url "http://paperswelove.org"
   :license {:name "Eclipse Public License"

--- a/src/calligraphus/core.clj
+++ b/src/calligraphus/core.clj
@@ -88,7 +88,9 @@
         urls (remove nil? (map :meetup_url chapters))
         sorted (partition-by :api (sort-by :api (map process-url urls)))
         chapter-map (reduce build-map {} sorted)]
-    (spit file-out (yaml/generate-string chapter-map))))
+    (if (false? chapter-map)
+      (exit 1 (error-msg ["Throttled by Meetup.com!"]))
+      (spit file-out (yaml/generate-string chapter-map)))))
 
 (defn -main
   "CLI interface from uberjar"


### PR DESCRIPTION
Meetup.com periodically throttles us agressively (even if we try to back
off). This update does two things, attempts to back off earlier, and
also prevent a save if we get any 429s from the API.